### PR TITLE
Add support for posting as inferred bot users

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ All configuration is done with environment variables. These are the vars used:
 | PORT | the port number to listen on | n | 6666 |
 | MOUNT_POINT | the path to mount the hook on | n | `/incoming` |
 | SERVICE_NAME | used in logging | n | `hooks-bot` |
+| INFER_BOT_USER | post as the inferred bot user (bot needs to be in the channel!) | n | - |
 
 ## License
 

--- a/configuration.tmpl
+++ b/configuration.tmpl
@@ -10,3 +10,4 @@ processes = 1
   SLACK_CHANNEL = "{{slack_channel}}"
   SHARED_SECRET = "{{hook_shared_secret}}"
   MOUNT_POINT = "/incoming"
+  INFER_BOT_USER = ""

--- a/index.js
+++ b/index.js
@@ -18,6 +18,12 @@ var port = process.env.PORT || '6666';
 // This is how we post to slack.
 var web = new slack.WebClient(token);
 
+// We can post the generic bot, or attempt to post as an inferred bot user.
+// If enabled, the bot user must be in the channel.
+var messageOpts = {
+	as_user: process.env.INFER_BOT_USER ? true : false
+};
+
 // Make a webhooks receiver and have it act on interesting events.
 // The receiver is a restify server!
 var opts = {
@@ -81,12 +87,12 @@ server.on('hook', function onIncomingHook(hook)
 		].join('\n');
 	}
 
-	web.chat.postMessage(channelID, message);
+	web.chat.postMessage(channelID, message, messageOpts);
 });
 
 server.on('hook:error', function(message)
 {
-	web.chat.postMessage(channelID, '*error handling web hook:* ' + message);
+	web.chat.postMessage(channelID, '*error handling web hook:* ' + message, messageOpts);
 });
 
 // now make it ready for production
@@ -105,5 +111,5 @@ server.get('/ping', function handlePing(request, response, next)
 server.listen(port, function()
 {
 	logger.info('listening on ' + port);
-	web.chat.postMessage(channelID, 'npm hooks slackbot coming on line beep boop');
+	web.chat.postMessage(channelID, 'npm hooks slackbot coming on line beep boop', messageOpts);
 });


### PR DESCRIPTION
Hey there!

Slack posts the hook messages with the generic bot. The messages should, instead, be by the bot user that was created to generate the API token.

![image](https://cloud.githubusercontent.com/assets/1560301/25932764/9cc28b9a-3656-11e7-99cc-8a7d1299be1d.png)

It probably shouldn't be the default behaviour though, because you need to remember to invite the bot to the configured slack channel.

To these ends I've added a `INFER_BOT_USER` env config, that if truthy (containing text eg `"true"`).

I've tested this live with [https://glitch.com/~npm-hook-slack](https://glitch.com/~npm-hook-slack)