### PR TITLE
Remove startup message posted to slack

### DIFF
--- a/index.js
+++ b/index.js
@@ -111,5 +111,4 @@ server.get('/ping', function handlePing(request, response, next)
 server.listen(port, function()
 {
 	logger.info('listening on ' + port);
-	web.chat.postMessage(channelID, 'npm hooks slackbot coming on line beep boop', messageOpts);
 });


### PR DESCRIPTION
Hey again, thanks for mergin #1 ✨ 

In hosting environments that boot up the node server on-demand we begin to see a lot of startup messages being posted to slack.

Question: Should it be kept around, and disabled via env var for use cases like mine?